### PR TITLE
repeat until no hace uso de begin y end

### DIFF
--- a/expressiones_y_sentencias.doslang
+++ b/expressiones_y_sentencias.doslang
@@ -157,7 +157,6 @@ begin
   desorden(a);
   n := 150;(*funcion HIGH no existe en el lenguaje*)
   repeat
-  BEGIN
 	newn := 0;
 	for i := 51 to n   do
 	  begin
@@ -168,7 +167,6 @@ begin
 		  end;
 	  end ;
 	n := newn;
-  END;
   until n <> 0;(*se realizaba solo una iteracion*)
 end;
 


### PR DESCRIPTION
En la página 50 en las consideraciones se menciona que el bloque repeat until no hace uso de begin end.