### PR TITLE
Cambio en indices de acceso y sentencia Repeat-Until

### DIFF
--- a/expressiones_y_sentencias.doslang
+++ b/expressiones_y_sentencias.doslang
@@ -146,7 +146,7 @@ var
 begin
   for i:= 50 to 149 do
   begin
-	  a[149 - i + 50] := i;(*debido al cambio que se hizo en el rango del arreglo en linea 31*)
+	  a[149 - i + 50] := i;
   end;
 end;
 

--- a/expressiones_y_sentencias.doslang
+++ b/expressiones_y_sentencias.doslang
@@ -144,9 +144,9 @@ procedure desorden(var a: array[50..150] of TItemBubbleSort);
 var
 	i:numero;
 begin
-  for i:= 0 to 100 do
+  for i:= 50 to 149 do
   begin
-	  a[100-i] := i;(*debido al cambio que se hizo en el rango del arreglo en linea 31*)
+	  a[149 - i + 50] := i;(*debido al cambio que se hizo en el rango del arreglo en linea 31*)
   end;
 end;
 
@@ -155,10 +155,10 @@ var
   n, newn, i:integer;
 begin
   desorden(a);
-  n := 150;(*funcion HIGH no existe en el lenguaje*)
+  n := 149;(*funcion HIGH no existe en el lenguaje*)
   repeat
 	newn := 0;
-	for i := 51 to n   do
+	for i := 51 to n do
 	  begin
 		if a[ i - 1 ] > a[ i ] then
 		  begin
@@ -167,7 +167,7 @@ begin
 		  end;
 	  end ;
 	n := newn;
-  until n <> 0;(*se realizaba solo una iteracion*)
+  until n = 0;(*se realizaba solo una iteracion*)
 end;
 
 
@@ -183,7 +183,7 @@ begin
    ordenamiento(arr);
    writeln(arr[120]);
    
-   for a:=0 to 100 do
+   for a:=50 to 149 do
 	writeln(arr[a]);
    
 end.


### PR DESCRIPTION
Los indices para acceder al arreglo eran incorrectos, ademas se cambio la condición de salida del repeat de <> a = debido a que en el enunciado se menciona lo siguiente
**El bloque de sentencias se ejecutará una vez y se seguirá ejecutando _**mientras**_ la condición sea verdadera (1 𝑎 𝑛 𝑣𝑒𝑐𝑒𝑠), de lo contrario el programa continuará con su flujo de ejecución normal.** 

Por lo tanto tiene el mismo funcionamiento de un do-While, si se dejaba con el <> se quedaría enciclado porque la condición siempre era verdadera.

el rango para iterar con un for debe ser de 50 a 149 debido a que la ultima iteración de este seria con **a = 149**, si se dejaba con 150 lo haria **a = 150** estando fuera del rango, esto porque el for es <=.