### PR TITLE
Arreglando ciclo until

### DIFF
--- a/expressiones_y_sentencias.doslang
+++ b/expressiones_y_sentencias.doslang
@@ -167,7 +167,7 @@ begin
 		  end;
 	  end ;
 	n := newn;
-  until n <> 0;(*se realizaba solo una iteracion*)
+  until n = 0;(*se realizaba solo una iteracion*)
 end;
 
 


### PR DESCRIPTION
En el ejemplo del enunciado al igual que en Pascal el ciclo until se ejecuta hasta que la condición sea verdadera, por lo que solo entraba una vez al ciclo.